### PR TITLE
Fixed failing Docker build

### DIFF
--- a/resin-route/Dockerfile.template
+++ b/resin-route/Dockerfile.template
@@ -1,11 +1,9 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-debian:stretch
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:stretch
 
 WORKDIR /usr/src/app
 ENV INITSYSTEM on
 
-RUN apt-get update && \
-    apt-get install -yq --no-install-recommends \
-          dnsmasq iptables
+RUN install_packages dnsmasq iptables
 
 COPY wifi-to-eth-route.sh ./
 


### PR DESCRIPTION
The balenaHub app build is failing and this should fix things: 

- Updated base image to a newer alternative 
- Convert `apt-get` to use `install-packages` utility instead that comes packed with all balena base images: https://www.balena.io/docs/reference/base-images/base-images/

```
[Error]         Some services failed to build:
[Error]           Service: resin-route
[Error]             Error: pull access denied for resin/raspberrypi4-64-debian, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```